### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -9,6 +9,10 @@ on:
       script:
         required: false
         default: "npm run build && npm run pack"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -23,3 +27,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: ${{ inputs.script }}
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit-package.yml
+++ b/.github/workflows/audit-package.yml
@@ -14,6 +14,10 @@ on:
       script:
         required: false
         default: "npm run build && npm run pack"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -24,6 +28,7 @@ jobs:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
       script: ${{ inputs.script || 'npm run build && npm run pack' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -14,7 +14,11 @@ on:
         description: "Run mode: cherry-pick or verify"
         required: false
         default: "cherry-pick"
-        
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
+
   pull_request:
     types: [opened, synchronize, labeled]
 
@@ -34,3 +38,4 @@ jobs:
       base_branch: ${{ inputs.base_branch }}
       script: ${{ inputs.script }}
       mode: ${{ github.event_name == 'pull_request' && 'verify' || inputs.mode }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Setup GH CLI Action
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -46406,18 +46406,38 @@ catch (error) {
     core.setFailed(error.message);
 }
 async function validateSubscription() {
-    const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    let repoPrivate;
+    if (eventPath && external_fs_.existsSync(eventPath)) {
+        const eventData = JSON.parse(external_fs_.readFileSync(eventPath, 'utf8'));
+        repoPrivate = eventData?.repository?.private;
+    }
+    const upstream = 'sersoft-gmbh/setup-gh-cli-action';
+    const action = process.env.GITHUB_ACTION_REPOSITORY;
+    const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+    core.info('');
+    core.info('[1;36mStepSecurity Maintained Action[0m');
+    core.info(`Secure drop-in replacement for ${upstream}`);
+    if (repoPrivate === false)
+        core.info('[32m✓ Free for public repositories[0m');
+    core.info(`[36mLearn more:[0m ${docsUrl}`);
+    core.info('');
+    if (repoPrivate === false)
+        return;
+    const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const body = { action: action || '' };
+    if (serverUrl !== 'https://github.com')
+        body.ghes_server = serverUrl;
     try {
-        await lib_axios.get(API_URL, { timeout: 3000 });
+        await lib_axios.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
     }
     catch (error) {
         if (axios_isAxiosError(error) && error.response?.status === 403) {
-            core.error('Subscription is not valid. Reach out to support@stepsecurity.io');
+            core.error(`[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`);
+            core.error(`[31mLearn how to enable a subscription: ${docsUrl}[0m`);
             process.exit(1);
         }
-        else {
-            core.info('Timeout or API not reachable. Continuing to next step.');
-        }
+        core.info('Timeout or API not reachable. Continuing to next step.');
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -228,18 +228,48 @@ try {
 }
 
 async function validateSubscription(): Promise<void> {
-    const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate: boolean | undefined
 
-    try {
-        await axios.get(API_URL, {timeout: 3000});
-    } catch (error) {
-        if (isAxiosError(error) && error.response?.status === 403) {
-            core.error(
-                'Subscription is not valid. Reach out to support@stepsecurity.io'
-            );
-            process.exit(1);
-        } else {
-            core.info('Timeout or API not reachable. Continuing to next step.');
-        }
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData?.repository?.private
+  }
+
+  const upstream = 'sersoft-gmbh/setup-gh-cli-action'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('[1;36mStepSecurity Maintained Action[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('[32m✓ Free for public repositories[0m')
+  core.info(`[36mLearn more:[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body: Record<string, string> = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
+  try {
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 403) {
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`
+      )
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`
+      )
+      process.exit(1)
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
+  }
 }


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z